### PR TITLE
feat: Pass data between plugins

### DIFF
--- a/protocol/v1/saturnbot.proto
+++ b/protocol/v1/saturnbot.proto
@@ -23,6 +23,7 @@ message ExecuteActionsResponse {
   optional string error = 1;
   // Template variables are received by saturn-bot and passed to templates of pull request title or pull request body.
   map<string, string> template_vars = 2;
+  map<string, string> plugin_data = 3;
 }
 
 message ExecuteFiltersRequest {
@@ -34,6 +35,7 @@ message ExecuteFiltersResponse {
   optional string error = 2;
   // Template variables are received by saturn-bot and passed to templates of pull request title or pull request body.
   map<string, string> template_vars = 3;
+  map<string, string> plugin_data = 4;
 }
 
 message GetPluginRequest {
@@ -49,6 +51,7 @@ message GetPluginResponse {
 message Context {
   Repository repository = 1; // Details on the repository to filter or apply actions to.
   optional PullRequest pull_request = 2; // Details on the pull request. Set only if a pull request exists.
+  map<string, string> plugin_data = 3;
 }
 
 message PullRequest {

--- a/protocol/v1/saturnbot.proto
+++ b/protocol/v1/saturnbot.proto
@@ -23,6 +23,7 @@ message ExecuteActionsResponse {
   optional string error = 1;
   // Template variables are received by saturn-bot and passed to templates of pull request title or pull request body.
   map<string, string> template_vars = 2;
+  // Plugin data contains arbitrary data set by the plugin. The data is then passed along to other plugins.
   map<string, string> plugin_data = 3;
 }
 
@@ -35,6 +36,7 @@ message ExecuteFiltersResponse {
   optional string error = 2;
   // Template variables are received by saturn-bot and passed to templates of pull request title or pull request body.
   map<string, string> template_vars = 3;
+  // Plugin data contains arbitrary data set by the plugin. The data is then passed along to other plugins.
   map<string, string> plugin_data = 4;
 }
 
@@ -51,6 +53,7 @@ message GetPluginResponse {
 message Context {
   Repository repository = 1; // Details on the repository to filter or apply actions to.
   optional PullRequest pull_request = 2; // Details on the pull request. Set only if a pull request exists.
+  // Plugin data contains arbitrary data set by other plugins.
   map<string, string> plugin_data = 3;
 }
 

--- a/protocol/v1/saturnbot.proto
+++ b/protocol/v1/saturnbot.proto
@@ -23,7 +23,7 @@ message ExecuteActionsResponse {
   optional string error = 1;
   // Template variables are received by saturn-bot and passed to templates of pull request title or pull request body.
   map<string, string> template_vars = 2;
-  // Plugin data contains arbitrary data set by the plugin. The data is then passed along to other plugins.
+  // Plugin data contains arbitrary data set by the plugin. The data is then passed on to other plugins by saturn-bot.
   map<string, string> plugin_data = 3;
 }
 
@@ -36,7 +36,7 @@ message ExecuteFiltersResponse {
   optional string error = 2;
   // Template variables are received by saturn-bot and passed to templates of pull request title or pull request body.
   map<string, string> template_vars = 3;
-  // Plugin data contains arbitrary data set by the plugin. The data is then passed along to other plugins.
+  // Plugin data contains arbitrary data set by the plugin. The data is then passed on to other plugins by saturn-bot.
   map<string, string> plugin_data = 4;
 }
 


### PR DESCRIPTION
A plugin can set arbitrary data and send it back to saturn-bot. All plugins called after that plugin receive the data.